### PR TITLE
chore: emitting batchOfferRevoked event

### DIFF
--- a/src/batchoffer/BatchOffer.sol
+++ b/src/batchoffer/BatchOffer.sol
@@ -110,6 +110,8 @@ contract BatchOfferCreator is
 
     // Refund Escrow
     marketConfig.refund(offer.currency, offer.amount, offer.feePercentage, offer.creator);
+
+    emit BatchOfferRevoked(msg.sender, _rootHash, offer.currency, offer.amount);
   }
 
   function acceptBatchOffer(

--- a/src/batchoffer/IBatchOffer.sol
+++ b/src/batchoffer/IBatchOffer.sol
@@ -32,4 +32,11 @@ interface IBatchOffer {
     address currency,
     uint256 amount
   );
+
+  event BatchOfferRevoked(
+    address indexed creator,
+    bytes32 rootHash,
+    address currency,
+    uint256 amount
+  );
 }


### PR DESCRIPTION
We want to emit an event when `BatchOfferRevoked` function is called